### PR TITLE
fix loaded svg always being centered unless a srcCompat is defined in xml

### DIFF
--- a/library/src/main/java/ch/qoqa/glide/svg/SvgBitmapTranscoder.kt
+++ b/library/src/main/java/ch/qoqa/glide/svg/SvgBitmapTranscoder.kt
@@ -7,11 +7,14 @@ import com.bumptech.glide.load.Options
 import com.bumptech.glide.load.engine.Resource
 import com.bumptech.glide.load.resource.SimpleResource
 import com.bumptech.glide.load.resource.transcode.ResourceTranscoder
+import com.caverock.androidsvg.PreserveAspectRatio
 import com.caverock.androidsvg.SVG
 
 class SvgBitmapTranscoder : ResourceTranscoder<SVG, Bitmap> {
     override fun transcode(toTranscode: Resource<SVG>, options: Options): Resource<Bitmap> {
         val svg = toTranscode.get()
+        svg.documentPreserveAspectRatio = PreserveAspectRatio.START
+
         val width = svg.documentWidth.toInt().takeIf { it > 0 }
                 ?: (svg.documentViewBox.right - svg.documentViewBox.left).toInt()
         val height = svg.documentHeight.toInt().takeIf { it > 0 }


### PR DESCRIPTION
**changes**
* In `SvgBitmapTranscoder` set `svg.documentPreserveAspectRatio = PreserveAspectRatio.START`


**issues**
* svgs would always be centered within the view, even when properties were set to specify otherwise, with the exception being when a srcCompat image was defined in xml. See this glide issue for more info, and for the fix included in this PR:
https://github.com/bumptech/glide/issues/4450#issuecomment-752163018